### PR TITLE
Enemy tank collider2

### DIFF
--- a/BattleScene.cpp
+++ b/BattleScene.cpp
@@ -4,6 +4,7 @@
 #include "Tank.h"
 #include "CommonFunction.h"
 #include "EnemyTankFactory.h"
+#include "EnemyTanks.h"
 #include "AmmoManager.h"
 #define POS 8
 
@@ -58,12 +59,21 @@ HRESULT BattleScene::Init()
 
 void BattleScene::Update()
 {
+    for (int i = 0; i < 4; i++)playerTank->SetVecEnemyTank(enemyTankFactory[i]->vecEnemyTank, i);
+
     for (int i = 0; i < 4; i++) {
-        enemyTankFactory[i]->Update();
+        for (int j = 0; j < 4; j++) {
+            for (vector<EnemyTanks*>::iterator it = enemyTankFactory[i]->vecEnemyTank.begin();
+                it != enemyTankFactory[i]->vecEnemyTank.end();
+                it++)
+            {
+                (*it)->SetVecEnemyTank(enemyTankFactory[j]->vecEnemyTank, j);
+            }
+        }
     }
 
+    for (int i = 0; i < 4; i++) enemyTankFactory[i]->Update();
     playerTank->Update();
-    ammoMgr->Update();
 }
 
 void BattleScene::Render(HDC hdc)

--- a/BattleScene.h
+++ b/BattleScene.h
@@ -5,6 +5,7 @@
 class Tank;
 class Image;
 class PlayerTank;
+class EnemyTanks;
 class EnemyTankFactory;
 class AmmoManager;
 class BattleScene : public GameEntity
@@ -14,6 +15,8 @@ private:
 	Tank* enemyTank;
 	EnemyTankFactory* enemyTankFactory[4];
 	PlayerTank* playerTank;
+
+	vector<EnemyTanks*> vecEnemyTank[4];
 
 	// 타일 샘플정보
 	Image* sampleImage;

--- a/BigEnemyTank.cpp
+++ b/BigEnemyTank.cpp
@@ -1,11 +1,12 @@
 #include "BigEnemyTank.h"
+void BigEnemyTank::SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num)
+{
+	this->vecEnemyTanks[num] = vecEnemyTank;
+}
 HRESULT BigEnemyTank::Init()
 {
 
 	img = ImageManager::GetSingleton()->FindImage("Image/Enemy/Enemy.bmp");
-	pos.x = 64+8;
-	pos.y = 16;
-
 	moveSpeed = 50;
 
 	return S_OK;

--- a/BigEnemyTank.h
+++ b/BigEnemyTank.h
@@ -3,6 +3,7 @@
 class BigEnemyTank : public EnemyTanks
 {
 public:
+	void SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num) override;
 	HRESULT Init() override;
 	void Update() override;
 	void Render(HDC hdc) override;

--- a/EnemyTankFactory.cpp
+++ b/EnemyTankFactory.cpp
@@ -15,6 +15,17 @@ void EnemyTankFactory::NewEnemyTank(TILE_INFO(*tileInfo)[TILE_COUNT], PlayerTank
 	vecEnemyTank.back()->SetPlyaerRect(playerTank);
 }
 
+void EnemyTankFactory::SetVecEnemyTanks(vector<EnemyTanks*> vecEnemyTank, int num)
+{
+	for (vector<EnemyTanks*>::iterator it = vecEnemyTank.begin();
+		it != vecEnemyTank.end();
+		it++)
+	{
+		(*it)->SetVecEnemyTank(vecEnemyTank, num);
+	}
+}
+
+
 EnemyTankFactory::~EnemyTankFactory()
 {
 	for (vector<EnemyTanks*>::iterator it = vecEnemyTank.begin();

--- a/EnemyTankFactory.h
+++ b/EnemyTankFactory.h
@@ -14,7 +14,7 @@ protected:
 public:
 	vector<EnemyTanks*> vecEnemyTank;
 	void NewEnemyTank(TILE_INFO(*tileInfo)[TILE_COUNT], PlayerTank& playerTank, int posX);
-
+	void SetVecEnemyTanks(vector<EnemyTanks*> vecEnemyTank, int num);
 	virtual HRESULT Init() = 0;
 	virtual void Update() = 0;
 	virtual void Render(HDC hdc) = 0;

--- a/EnemyTanks.cpp
+++ b/EnemyTanks.cpp
@@ -126,7 +126,7 @@ void EnemyTanks::TankUpdate()
                     it++)
                 {
                     RECT enemyRect = (*it)->GetRect();
-                    if (IntersectRect(&rc, &shape, &enemyRect)) {
+                    if (IntersectRect(&rc, &shape, &enemyRect) || IntersectRect(&rc, playerRect, &shape)) {
                         count++;
                     }
                 }

--- a/EnemyTanks.h
+++ b/EnemyTanks.h
@@ -10,12 +10,15 @@ class EnemyTanks : public GameObject
 {
 private:
 protected:
+	vector<EnemyTanks*> vecEnemyTanks[4];
+
 	void CollisionAndMove(MoveDir moveDir);
 	void PosReset(MoveDir moveDir);
 	void TankUpdate();
 	int CurrFrame(Image enemyTank, int* elapsedCount, int setCurr);
 	tuple<MoveDir, bool> AutoMove(MoveDir moveDir, POINTFLOAT pos);
 	TILE_INFO(*tileInfo)[TILE_COUNT];
+	bool spawnColl;
 
 	RECT* playerRect;
 	MoveDir movedir;
@@ -39,6 +42,7 @@ public:
 	virtual void Update() = 0;
 	virtual void Render(HDC hdc) = 0;
 	virtual void Release() = 0;
+	virtual void SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num) = 0;
 	inline RECT GetRect() { return this->shape; }
 
 	EnemyTanks() {}

--- a/FastMoveEnemyTank.cpp
+++ b/FastMoveEnemyTank.cpp
@@ -1,11 +1,14 @@
 #include "FastMoveEnemyTank.h"
 
+void FastMoveEnemyTank::SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num)
+{
+	this->vecEnemyTanks[num] = vecEnemyTank;
+}
+
 HRESULT FastMoveEnemyTank::Init()
 {
 
 	img = ImageManager::GetSingleton()->FindImage("Image/Enemy/Enemy.bmp");
-	pos.x = 32+8;
-	pos.y = 16;
 	moveSpeed = 50;
 
 	return S_OK;

--- a/FastMoveEnemyTank.h
+++ b/FastMoveEnemyTank.h
@@ -3,6 +3,7 @@
 class FastMoveEnemyTank : public EnemyTanks
 {
 public:
+	void SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num) override;
 	HRESULT Init() override;
 	void Update() override;
 	void Render(HDC hdc) override;

--- a/FastShootEnemyTank.cpp
+++ b/FastShootEnemyTank.cpp
@@ -1,12 +1,14 @@
 #include "FastShootEnemyTank.h"
 
+void FastShootEnemyTank::SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num)
+{
+	this->vecEnemyTanks[num] = vecEnemyTank;
+}
+
 HRESULT FastShootEnemyTank::Init()
 {
 
 	img = ImageManager::GetSingleton()->FindImage("Image/Enemy/Enemy.bmp");
-	pos.x = 48+8;
-	pos.y = 16;
-
 	moveSpeed = 50;
     return S_OK;
 }

--- a/FastShootEnemyTank.h
+++ b/FastShootEnemyTank.h
@@ -3,6 +3,7 @@
 class FastShootEnemyTank : public EnemyTanks
 {
 public:
+	void SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num) override;
 	HRESULT Init() override;
 	void Update() override;
 	void Render(HDC hdc) override;

--- a/NormalEnemyTank.cpp
+++ b/NormalEnemyTank.cpp
@@ -1,11 +1,14 @@
 #include "NormalEnemyTank.h"
 
+void NormalEnemyTank::SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num)
+{
+	this->vecEnemyTanks[num] = vecEnemyTank;
+}
+
 HRESULT NormalEnemyTank::Init()
 {
 
 	img = ImageManager::GetSingleton()->FindImage("Image/Enemy/Enemy.bmp");
-	pos.x = 16+8;
-	pos.y = 16;
 	moveSpeed = 50;
 	return S_OK;
 }

--- a/NormalEnemyTank.h
+++ b/NormalEnemyTank.h
@@ -3,6 +3,7 @@
 class NormalEnemyTank : public EnemyTanks
 {
 public:
+	void SetVecEnemyTank(vector<EnemyTanks*> vecEnemyTank, int num) override;
 	HRESULT Init() override;
 	void Update() override;
 	void Render(HDC hdc) override;


### PR DESCRIPTION
탱크가 서로간의 충돌검사 추가
스폰시 적탱크나 자신의 탱크가 겹쳐있으면 겹침이 풀릴떄까지 충돌 무시.
적탱크 콜라이더 검색 최적화.
소소한 버그픽스